### PR TITLE
build/chore: ignore deprecated build.yml workflow file for dependabot, added comment about deprecation and auto-build of :beta on current workflow file (buildeux.yml)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       prefix: "chore: "
     reviewers:
       - "fetzu"
+    ignore:
+      - dependency-name: "/.github/workflows/build.yml"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -29,6 +31,8 @@ updates:
       prefix: "chore: "
     reviewers:
       - "fetzu"
+    ignore:
+      - dependency-name: "/.github/workflows/build.yml"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -44,3 +48,5 @@ updates:
       prefix: "build: "
     reviewers:
       - "fetzu"
+    ignore:
+      - dependency-name: "/.github/workflows/build.yml"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+# !NOTE: This action is deprecated and currently disabled.
 # Build for amd64 and arm64 and publish to DockerHub
 name: build
 

--- a/.github/workflows/buildeux.yml
+++ b/.github/workflows/buildeux.yml
@@ -1,4 +1,5 @@
 # Build for amd64 and arm64 and publish to DockerHub and GitHub Packages
+# The :beta image is automatically re-built and pushed fortnightly to include changes to upstream images
 
 name: Build and publish Docker image
 


### PR DESCRIPTION
Just tidying up.