### PR TITLE
feat: make refresh rates configurable via env vars / CLI (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ ABRP:
     # - STATUS_TOPIC=teslamate-abrp
     # - SKIP_LOCATION=True
     # - TM2ABRP_DEBUG=True
+    # - REFRESH_RATE_DRIVING=1
+    # - REFRESH_RATE_CHARGING=6
+    # - REFRESH_RATE_PARKED=30
 ```
 
 Deploy the service:
@@ -139,6 +142,9 @@ secrets:
 | STATUS_TOPIC | Topic to publish status messages | - | No |
 | SKIP_LOCATION | Don't send location data to ABRP | False | No |
 | TM2ABRP_DEBUG | Enable debug logging | False | No |
+| REFRESH_RATE_DRIVING | Update interval (seconds) while driving | 1 | No |
+| REFRESH_RATE_CHARGING | Update interval (seconds) while charging | 6 | No |
+| REFRESH_RATE_PARKED | Update interval (seconds) while parked/asleep | 30 | No |
 
 ### Car Model Identification
 
@@ -174,12 +180,22 @@ Examples:
 
 ### Customizing Update Frequencies
 
-The application uses different update rates based on car state:
-- Driving: Updates every 1 second
-- Charging: Updates every 6 seconds
-- Parked/Asleep: Updates every 30 seconds
+The application uses different update rates (in seconds) based on car state, with these defaults:
+- Driving: every 1 second (`REFRESH_RATE_DRIVING`)
+- Charging: every 6 seconds (`REFRESH_RATE_CHARGING`)
+- Parked/Asleep: every 30 seconds (`REFRESH_RATE_PARKED`)
 
-These values can be customized by editing the constants at the top of the Python script.
+These can be customized via environment variables or the equivalent CLI options
+(`--refresh-driving`, `--refresh-charging`, `--refresh-parked`). Any value left
+unset falls back to the default above. Values must be whole positive seconds;
+invalid values are ignored (with a warning) and the default is used instead.
+
+For example, to make driving updates less aggressive:
+
+```yaml
+environment:
+  - REFRESH_RATE_DRIVING=5
+```
 
 ## Credits
 

--- a/teslamate_mqtt2abrp.py
+++ b/teslamate_mqtt2abrp.py
@@ -21,10 +21,10 @@ APIKEY = "d49234a5-2553-454e-8321-3fe30b49aa64"
 DEFAULT_MQTT_PORT = 1883
 DEFAULT_CAR_NUMBER = 1
 
-# Refresh rates (in seconds)
-REFRESH_RATE_DRIVING = 1
-REFRESH_RATE_CHARGING = 6
-REFRESH_RATE_PARKED = 30
+# Refresh rates (in seconds) - used as fallback defaults when not configured
+DEFAULT_REFRESH_RATE_DRIVING = 1
+DEFAULT_REFRESH_RATE_CHARGING = 6
+DEFAULT_REFRESH_RATE_PARKED = 30
 
 # Tesla model ID mapping
 MODEL_MAPPINGS = {
@@ -42,6 +42,23 @@ MODEL_MAPPINGS = {
     }
 }
 
+def validate_refresh_rate(value: Any, default: int, name: str) -> int:
+    """Validate a refresh rate, falling back to the default for missing/invalid values.
+
+    Refresh rates must be whole positive seconds (the update loop uses them as a
+    modulo divisor, so 0 or negative values are rejected).
+    """
+    if value is None:
+        return default
+    try:
+        rate = int(value)
+        if rate < 1:
+            raise ValueError
+        return rate
+    except (ValueError, TypeError):
+        logging.warning(f"Invalid {name} refresh rate provided: {value}. Using default: {default}s.")
+        return default
+
 ## [ la CLASSe américaine ]
 class TeslaMateABRP:
     def __init__(self, config):
@@ -57,6 +74,17 @@ class TeslaMateABRP:
         self.prev_state = ""
         self.charger_phases = 1
         self.has_usable_battery_level = False  # Flag to track if we've received usable_battery_level
+
+        # Refresh rates (in seconds), validated with fallback to defaults
+        self.refresh_rate_driving = validate_refresh_rate(
+            self.config.get("REFRESH_RATE_DRIVING"), DEFAULT_REFRESH_RATE_DRIVING, "driving"
+        )
+        self.refresh_rate_charging = validate_refresh_rate(
+            self.config.get("REFRESH_RATE_CHARGING"), DEFAULT_REFRESH_RATE_CHARGING, "charging"
+        )
+        self.refresh_rate_parked = validate_refresh_rate(
+            self.config.get("REFRESH_RATE_PARKED"), DEFAULT_REFRESH_RATE_PARKED, "parked"
+        )
         
         # Default data structure for ABRP
         self.data = {
@@ -455,9 +483,10 @@ class TeslaMateABRP:
             i += 1
             sleep(1)  # Base refresh rate
 
-            # Reset counter when state changes
+            # Reset counter when state changes so the first update fires promptly
+            # (0 % rate == 0 for any rate, regardless of the configured values)
             if self.state != self.prev_state:
-                i = max(REFRESH_RATE_PARKED, REFRESH_RATE_CHARGING, REFRESH_RATE_DRIVING)
+                i = 0
                 logging.debug(f"Current car state changed to: {self.state}.")
 
             # Update UTC timestamp
@@ -466,26 +495,27 @@ class TeslaMateABRP:
             # Handle different car states
             if self.state in ["parked", "online", "suspended", "asleep", "offline"]:
                 self.handle_parked_state(i)
-                if i % REFRESH_RATE_PARKED == 0 or i > REFRESH_RATE_PARKED:
+                if i % self.refresh_rate_parked == 0 or i > self.refresh_rate_parked:
                     if self.prev_state != self.state:
-                        logging.info(f"Car is sleeping, updating every {REFRESH_RATE_PARKED}s.")
+                        logging.info(f"Car is sleeping, updating every {self.refresh_rate_parked}s.")
                     self.update_abrp()
                     if self.base_topic:
                         self.publish_to_mqtt(self.data)
                     i = 0
             elif self.state == "charging":
-                if i % REFRESH_RATE_CHARGING == 0:
+                if i % self.refresh_rate_charging == 0:
                     if self.prev_state != self.state:
-                        logging.info(f"Car is charging, updating every {REFRESH_RATE_CHARGING}s.")
+                        logging.info(f"Car is charging, updating every {self.refresh_rate_charging}s.")
                     self.update_abrp()
                     if self.base_topic:
                         self.publish_to_mqtt(self.data)
             elif self.state == "driving":
-                if self.prev_state != self.state:
-                    logging.info(f"Car is driving, updating every {REFRESH_RATE_DRIVING}s.")
-                self.update_abrp()
-                if self.base_topic:
-                    self.publish_to_mqtt(self.data)
+                if i % self.refresh_rate_driving == 0:
+                    if self.prev_state != self.state:
+                        logging.info(f"Car is driving, updating every {self.refresh_rate_driving}s.")
+                    self.update_abrp()
+                    if self.base_topic:
+                        self.publish_to_mqtt(self.data)
             elif self.state:  # Any other non-empty state
                 logging.error(f"Car is in unknown state ({self.state}), not sending any update to ABRP.")
                 
@@ -557,9 +587,16 @@ def get_docker_secret(secret_name: str) -> Optional[str]:
              help='Verify TLS certificates (default: True)')
 @click.option('-x', '--skip-location', 'skip_location', is_flag=True, envvar='SKIP_LOCATION',
              help="Don't send LAT and LON to ABRP")
+@click.option('--refresh-driving', 'refresh_driving', type=int, envvar='REFRESH_RATE_DRIVING',
+             help=f'Update interval in seconds while driving (default: {DEFAULT_REFRESH_RATE_DRIVING})')
+@click.option('--refresh-charging', 'refresh_charging', type=int, envvar='REFRESH_RATE_CHARGING',
+             help=f'Update interval in seconds while charging (default: {DEFAULT_REFRESH_RATE_CHARGING})')
+@click.option('--refresh-parked', 'refresh_parked', type=int, envvar='REFRESH_RATE_PARKED',
+             help=f'Update interval in seconds while parked/asleep (default: {DEFAULT_REFRESH_RATE_PARKED})')
 
 def main(user_token, car_number, mqtt_server, mqtt_username, mqtt_password, mqtt_port,
-         car_model, status_topic, debug, use_auth, use_tls, verify_cert, skip_location):
+         car_model, status_topic, debug, use_auth, use_tls, verify_cert, skip_location,
+         refresh_driving, refresh_charging, refresh_parked):
     """teslamate-abrp
 
     A slightly convoluted way of getting your vehicle data from TeslaMate to A Better Route Planner.
@@ -633,6 +670,11 @@ def main(user_token, car_number, mqtt_server, mqtt_username, mqtt_password, mqtt
     config["BASETOPIC"] = status_topic
     config["SKIPLOCATION"] = skip_location
     config["DEBUG"] = debug
+
+    # Refresh rates (validated with fallback to defaults inside TeslaMateABRP)
+    config["REFRESH_RATE_DRIVING"] = refresh_driving
+    config["REFRESH_RATE_CHARGING"] = refresh_charging
+    config["REFRESH_RATE_PARKED"] = refresh_parked
 
     # Enhanced credential logging for troubleshooting
     if config["MQTTUSERNAME"]:

--- a/tests/test_teslamate_mqtt2abrp.py
+++ b/tests/test_teslamate_mqtt2abrp.py
@@ -6,7 +6,15 @@ import sys
 import types
 import importlib
 from unittest.mock import patch, MagicMock, mock_open, call
-from teslamate_mqtt2abrp import TeslaMateABRP, DEFAULT_MQTT_PORT, main
+from teslamate_mqtt2abrp import (
+    TeslaMateABRP,
+    DEFAULT_MQTT_PORT,
+    DEFAULT_REFRESH_RATE_DRIVING,
+    DEFAULT_REFRESH_RATE_CHARGING,
+    DEFAULT_REFRESH_RATE_PARKED,
+    validate_refresh_rate,
+    main,
+)
 
 @pytest.fixture
 def mock_args():
@@ -616,7 +624,10 @@ def test_main_with_click_mocked(mock_command):
                     use_auth=False,
                     use_tls=False,
                     skip_location=False,
-                    verify_cert=True
+                    verify_cert=True,
+                    refresh_driving=None,
+                    refresh_charging=None,
+                    refresh_parked=None
                 )
                 
                 # Check TeslaMateABRP was instantiated with correct config
@@ -666,7 +677,10 @@ def test_main_missing_required_args_direct():
                         use_auth=False,
                         use_tls=False,
                         skip_location=False,
-                        verify_cert=True
+                        verify_cert=True,
+                        refresh_driving=None,
+                        refresh_charging=None,
+                        refresh_parked=None
                     )
                     pytest.fail("Expected MockExit exception")
                 except MockExit as e:
@@ -692,7 +706,10 @@ def test_main_missing_required_args_direct():
                         use_auth=False,
                         use_tls=False,
                         skip_location=False,
-                        verify_cert=True
+                        verify_cert=True,
+                        refresh_driving=None,
+                        refresh_charging=None,
+                        refresh_parked=None
                     )
                     pytest.fail("Expected MockExit exception")
                 except MockExit as e:
@@ -729,7 +746,10 @@ def test_main_with_docker_secrets_mocked_click(mock_command):
                     use_auth=True,  # Enable auth but don't provide password
                     use_tls=False,
                     skip_location=False,
-                    verify_cert=True
+                    verify_cert=True,
+                    refresh_driving=None,
+                    refresh_charging=None,
+                    refresh_parked=None
                 )
                 
                 # Check Docker secret was used for token
@@ -777,7 +797,10 @@ def test_main_run_exceptions_with_click_mock(mock_command):
                 use_auth=False,
                 use_tls=False,
                 skip_location=False,
-                verify_cert=True
+                verify_cert=True,
+                refresh_driving=None,
+                refresh_charging=None,
+                refresh_parked=None
             )
             
             # Should exit cleanly with code 0
@@ -801,7 +824,10 @@ def test_main_run_exceptions_with_click_mock(mock_command):
                 use_auth=False,
                 use_tls=False,
                 skip_location=False,
-                verify_cert=True
+                verify_cert=True,
+                refresh_driving=None,
+                refresh_charging=None,
+                refresh_parked=None
             )
             
             # Should exit with error code 1
@@ -1301,6 +1327,133 @@ def test_battery_level_fallback(teslamate_abrp):
 #        abrp = TeslaMateABRP(mock_args)
 #        assert hasattr(abrp, 'has_usable_battery_level')
 #        assert abrp.has_usable_battery_level is False
+
+# [ Refresh rate configuration tests (issue #86) ]
+def test_validate_refresh_rate():
+    """validate_refresh_rate should accept valid rates and fall back to defaults otherwise"""
+    # None means "not configured" -> use the default
+    assert validate_refresh_rate(None, 30, "parked") == 30
+    # Valid integers and integer-like strings are accepted
+    assert validate_refresh_rate(5, 1, "driving") == 5
+    assert validate_refresh_rate("12", 6, "charging") == 12
+    # Non-positive values are rejected (would break the modulo update loop)
+    assert validate_refresh_rate(0, 30, "parked") == 30
+    assert validate_refresh_rate(-5, 30, "parked") == 30
+    # Non-numeric values fall back to the default
+    assert validate_refresh_rate("abc", 6, "charging") == 6
+    assert validate_refresh_rate(1.5, 6, "charging") == 1  # int() truncates valid floats
+
+def test_refresh_rates_default(mock_args):
+    """When no refresh rates are configured, the documented defaults are used"""
+    with patch('teslamate_mqtt2abrp.mqtt.Client'):
+        abrp = TeslaMateABRP(mock_args)
+        assert abrp.refresh_rate_driving == DEFAULT_REFRESH_RATE_DRIVING
+        assert abrp.refresh_rate_charging == DEFAULT_REFRESH_RATE_CHARGING
+        assert abrp.refresh_rate_parked == DEFAULT_REFRESH_RATE_PARKED
+
+def test_refresh_rates_from_config(mock_args):
+    """Configured refresh rates override the defaults"""
+    config = mock_args.copy()
+    config["REFRESH_RATE_DRIVING"] = 5
+    config["REFRESH_RATE_CHARGING"] = 15
+    config["REFRESH_RATE_PARKED"] = 60
+    with patch('teslamate_mqtt2abrp.mqtt.Client'):
+        abrp = TeslaMateABRP(config)
+        assert abrp.refresh_rate_driving == 5
+        assert abrp.refresh_rate_charging == 15
+        assert abrp.refresh_rate_parked == 60
+
+def test_refresh_rates_invalid_config_falls_back(mock_args):
+    """Invalid configured refresh rates fall back to the defaults"""
+    config = mock_args.copy()
+    config["REFRESH_RATE_DRIVING"] = "not-a-number"
+    config["REFRESH_RATE_CHARGING"] = 0
+    config["REFRESH_RATE_PARKED"] = -10
+    with patch('teslamate_mqtt2abrp.mqtt.Client'):
+        abrp = TeslaMateABRP(config)
+        assert abrp.refresh_rate_driving == DEFAULT_REFRESH_RATE_DRIVING
+        assert abrp.refresh_rate_charging == DEFAULT_REFRESH_RATE_CHARGING
+        assert abrp.refresh_rate_parked == DEFAULT_REFRESH_RATE_PARKED
+
+def _run_driving_loop(refresh_rate_driving, iterations):
+    """Run the real update_timely loop in 'driving' state for a fixed number of
+    iterations and return how many times update_abrp was called."""
+    config = {
+        "DEBUG": False, "MQTTUSERNAME": None, "MQTTPASSWORD": None,
+        "MQTTTLS": False, "SKIPLOCATION": False, "USERTOKEN": 'test-token',
+        "CARNUMBER": '1', "MQTTSERVER": 'test-server', "MQTTPORT": '1883',
+        "CARMODEL": None, "BASETOPIC": None,
+        "REFRESH_RATE_DRIVING": refresh_rate_driving,
+    }
+    with patch('teslamate_mqtt2abrp.mqtt.Client'):
+        abrp = TeslaMateABRP(config)
+    abrp.state = "driving"
+    abrp.prev_state = "driving"  # avoid the state-change counter reset
+
+    sleep_calls = {"n": 0}
+    def fake_sleep(_seconds):
+        sleep_calls["n"] += 1
+        if sleep_calls["n"] > iterations:
+            raise KeyboardInterrupt()
+
+    with patch('teslamate_mqtt2abrp.sleep', side_effect=fake_sleep):
+        with patch.object(abrp, 'update_abrp') as mock_update:
+            with patch.object(abrp, 'publish_to_mqtt'):
+                try:
+                    abrp.update_timely()
+                except KeyboardInterrupt:
+                    pass
+    return mock_update.call_count
+
+def test_update_timely_respects_driving_refresh_rate():
+    """Driving updates must honor the configured rate (regression for issue #86).
+
+    Counter values i = 0..6 are covered by 7 iterations. With the default rate of
+    1, every iteration updates (7 calls). With a rate of 3, only i in {0, 3, 6}
+    update (3 calls) - previously the driving branch updated every iteration
+    regardless of the configured rate.
+    """
+    assert _run_driving_loop(1, 7) == 7
+    assert _run_driving_loop(3, 7) == 3
+
+@patch('teslamate_mqtt2abrp.click.command')
+def test_main_passes_refresh_rates_to_config(mock_command):
+    """main() should forward the refresh-rate options into the config dict"""
+    def mock_decorator(f):
+        return f
+    mock_command.return_value = mock_decorator
+
+    import teslamate_mqtt2abrp
+    importlib.reload(teslamate_mqtt2abrp)
+    try:
+        with patch('teslamate_mqtt2abrp.TeslaMateABRP') as mock_abrp:
+            with patch('teslamate_mqtt2abrp.get_docker_secret', return_value=None):
+                with patch('sys.exit'):
+                    teslamate_mqtt2abrp.main(
+                        user_token='test_token',
+                        car_number='1',
+                        mqtt_server='test_server',
+                        mqtt_username=None,
+                        mqtt_password=None,
+                        mqtt_port=None,
+                        car_model=None,
+                        status_topic=None,
+                        debug=False,
+                        use_auth=False,
+                        use_tls=False,
+                        skip_location=False,
+                        verify_cert=True,
+                        refresh_driving=5,
+                        refresh_charging=10,
+                        refresh_parked=60,
+                    )
+                    args, _ = mock_abrp.call_args
+                    config = args[0]
+                    assert config['REFRESH_RATE_DRIVING'] == 5
+                    assert config['REFRESH_RATE_CHARGING'] == 10
+                    assert config['REFRESH_RATE_PARKED'] == 60
+    finally:
+        importlib.reload(teslamate_mqtt2abrp)
 
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Closes #86

## What

Makes the driving / charging / parked update intervals configurable instead of hard-coded constants, while keeping the current values as fallback defaults (per the requirement in the issue).

| Setting | Env var | CLI option | Default |
|---|---|---|---|
| Driving interval | `REFRESH_RATE_DRIVING` | `--refresh-driving` | 1s |
| Charging interval | `REFRESH_RATE_CHARGING` | `--refresh-charging` | 6s |
| Parked/asleep interval | `REFRESH_RATE_PARKED` | `--refresh-parked` | 30s |

Implementation follows the existing `DEFAULT_MQTT_PORT` / `MQTT_PORT` pattern: a `DEFAULT_*` constant, a `@click.option(..., envvar=...)`, stored into the `config` dict, and consumed by the class. Values are validated as whole positive seconds; missing or invalid values fall back to the default with a warning.

## Bug fix included

The issue's actual complaint — *"refreshing every second while driving is too aggressive"* — exposed a latent bug: the **driving** branch ignored `REFRESH_RATE_DRIVING` and updated on *every* loop iteration. It now gates on the configured rate (`i % refresh_rate_driving == 0`), so e.g. `REFRESH_RATE_DRIVING=5` actually slows driving updates down.

The state-change counter reset was changed from `max(...)` to `0`. The old value only fired the first update immediately because 30 is divisible by 6 and 30; with arbitrary user rates that would delay the first update. `0 % rate == 0` for any rate, so the first update still fires promptly in every state. **Default behaviour (1 / 6 / 30s) is unchanged.**

## Tests

Adds tests for: the validation helper, default fallback, config override, invalid-value fallback, the driving refresh-rate regression (drives the real `update_timely` loop), and `main()` config wiring. Full suite passes (46 tests). `README.md` updated (parameter table, docker-compose example, Advanced Usage section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)